### PR TITLE
Resolve Java8 issues with updated jdepend version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <sonar.plugin-api.version>5.6</sonar.plugin-api.version>
     <sonar.orchestrator.version>3.13</sonar.orchestrator.version>
 
-    <jdepend.version>2.9.1</jdepend.version>
+    <jdepend.version>2.9.5</jdepend.version>
   </properties>
 
   <repositories>
@@ -90,7 +90,7 @@
     </dependency>
 
     <dependency>
-      <groupId>jdepend</groupId>
+      <groupId>guru.nidi</groupId>
       <artifactId>jdepend</artifactId>
       <version>${jdepend.version}</version>
     </dependency>

--- a/src/test/it/pom.xml
+++ b/src/test/it/pom.xml
@@ -49,6 +49,17 @@
         </configuration>
       </plugin>
     </plugins>
+    
+    <pluginManagement>
+      <plugins>
+        <plugin>        
+		  <groupId>org.sonarsource.scanner.maven</groupId>
+		  <artifactId>sonar-maven-plugin</artifactId>
+		  <version>3.2</version>
+        </plugin>        
+      </plugins>
+    </pluginManagement>
+    
   </build>
 
 </project>


### PR DESCRIPTION
Hi,

Thanks for a nice project, would be even nicer with complete java 8 support. Thinks the below will fix it.

Updated jdepend to a fork with better Java 8 support, https://github.com/nidi3/jdepend . 

Also set a specific sonar-maven-plugin version to get the test to pass, maybe just my environment. 


All the best, Pether